### PR TITLE
Always return an onupdate when updated

### DIFF
--- a/src/components/date-range-picker.tsx
+++ b/src/components/date-range-picker.tsx
@@ -312,13 +312,13 @@ export const DateRangePicker: FC<DateRangePickerProps> = ({
   );
 
   // Helper function to check if two date ranges are equal
-  const areRangesEqual = (a?: DateRange, b?: DateRange): boolean => {
-    if (!a || !b) return a === b; // If either is undefined, return true if both are undefined
-    return (
-      a.from.getTime() === b.from.getTime() &&
-      (!a.to || !b.to || a.to.getTime() === b.to.getTime())
-    );
-  };
+  // const areRangesEqual = (a?: DateRange, b?: DateRange): boolean => {
+  //   if (!a || !b) return a === b; // If either is undefined, return true if both are undefined
+  //   return (
+  //     a.from.getTime() === b.from.getTime() &&
+  //     (!a.to || !b.to || a.to.getTime() === b.to.getTime())
+  //   );
+  // };
 
   useEffect(() => {
     if (isOpen) {
@@ -549,12 +549,7 @@ export const DateRangePicker: FC<DateRangePickerProps> = ({
           <Button
             onClick={() => {
               setIsOpen(false);
-              if (
-                !areRangesEqual(range, openedRangeRef.current) ||
-                !areRangesEqual(rangeCompare, openedRangeCompareRef.current)
-              ) {
-                onUpdate?.({ range, rangeCompare });
-              }
+              onUpdate?.({ range, rangeCompare });
             }}
           >
             Update


### PR DESCRIPTION
The initial checks would sometimes fail even if the dates has been updated.

The checks have been temporarily disabled so that we can get an onUpdate event back to where the component was mounted